### PR TITLE
declare js-module within platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,11 +11,12 @@
 
     <name>File Opener</name>
 
-    <js-module src="www/fileopener.js" name="FileOpener">
-        <clobbers target="window.plugins.fileOpener" />
-    </js-module>
-
     <platform name="android">
+
+        <js-module src="www/fileopener.js" name="FileOpener">
+            <clobbers target="window.plugins.fileOpener" />
+        </js-module>
+
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FileOpener">
                 <param name="android-package" value="com.phonegap.plugins.fileopener.FileOpener"/>            


### PR DESCRIPTION
declare js-module within platform, otherwise cordova will try and install the plugin for all other installed platforms (in my case iOS).
