### PR TITLE
Open APK files - Update FileOpener.java

### DIFF
--- a/src/android/FileOpener.java
+++ b/src/android/FileOpener.java
@@ -90,7 +90,13 @@ public class FileOpener extends CordovaPlugin {
             // Video files
             intent = new Intent(Intent.ACTION_VIEW);
             intent.setDataAndType(uri, "video/*");
+        } else if(url.contains(".apk")) {
+            // Application files
+            intent = new Intent(Intent.ACTION_VIEW);
+            intent.setDataAndType(uri, "application/vnd.android.package-archive");
         }
+        
+        
                 
         //if you want you can also define the intent type for any other file
         


### PR DESCRIPTION
A added the intent of open an apk application.
You can fork if you want but now I must try the code first.
I think we must to add the permission to install package:
<uses-permission android:name="android.permission.INSTALL_PACKAGES" />
But I don't know how to do it automatically.
