### PR TITLE
Added missing js-module clobber for WP8 target

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,6 +27,11 @@
     </platform>
 
     <platform name="wp8">
+
+        <js-module src="www/fileopener.js" name="FileOpener">
+            <clobbers target="window.plugins.fileOpener" />
+        </js-module>
+        
         <config-file target="config.xml" parent="/*">
             <feature name="FileOpener">
                 <param name="wp-package" value="FileOpener"/>


### PR DESCRIPTION
"fileopener.js" was not copied to the WP8 platform when adding the plugin. Adding the js-module clobber to the WP8 platform fixed this.
